### PR TITLE
Add accessibilityLabel support

### DIFF
--- a/js/ProgressView.windows.js
+++ b/js/ProgressView.windows.js
@@ -20,6 +20,7 @@ const styles = StyleSheet.create({
 
 export default function ProgressViewWindows(props: WindowsNativeProps) {
   const nativeProps = {
+    accessibilityLabel: props.accessibilityLabel,
     testID: props.testID,
     progressViewStyle: props.progressViewStyle,
     progress: props.progress,

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -31,5 +31,7 @@ export type ProgressViewProps = ViewProps & {
    * A stretchable image to display behind the progress bar.
    */
   trackImage?: ImageSourcePropType,
+
+  accessibilityLabel?: String,
 };
 export class ProgressView extends React.Component<ProgressViewProps> {}

--- a/windows/progress-view/ProgressViewView.cpp
+++ b/windows/progress-view/ProgressViewView.cpp
@@ -51,6 +51,11 @@ namespace winrt::progress_view::implementation {
             else if (propertyName == "isIndeterminate") {
                 this->IsIndeterminate(propertyValue.AsBoolean());
             }
+            else if (propertyName == "accessibilityLabel") {
+                if (!propertyValue.IsNull()) {
+                    this->Name(to_hstring(propertyValue.AsString()));
+                }
+            }
             else if (propertyName == "progressImage") {
                 if (!propertyValue.IsNull()) {
                     auto imgUriString = propertyValue.AsObject()["uri"].AsString();

--- a/windows/progress-view/ProgressViewViewManager.cpp
+++ b/windows/progress-view/ProgressViewViewManager.cpp
@@ -37,6 +37,7 @@ namespace winrt::progress_view::implementation {
     // IViewManagerWithNativeProperties
     IMapView<hstring, ViewManagerPropertyType> ProgressViewViewManager::NativeProps() noexcept {
         auto nativeProps = winrt::single_threaded_map<hstring, ViewManagerPropertyType>();
+        nativeProps.Insert(L"accessibilityLabel", ViewManagerPropertyType::String);
         nativeProps.Insert(L"progress", ViewManagerPropertyType::Number);
         nativeProps.Insert(L"progressTintColor", ViewManagerPropertyType::Color);
         nativeProps.Insert(L"trackTintColor", ViewManagerPropertyType::Color);


### PR DESCRIPTION
Adds accessibilityLabel support to ProgressView. 

Currently, ProgressView doesn't appear to support accessibilityLabel, and the UIA Name property is always null on ProgressView components. This is an accessibility compliance issue for Windows apps, and is blocking the React Native Windows team on this issue: https://github.com/microsoft/react-native-gallery/issues/368

Screenshots to show changes:

Before: 
![Screenshot (41)](https://github.com/react-native-progress-view/progress-view/assets/30995198/305d8aa9-cd6b-46d0-8771-63cd6675a955)

After:
![Screenshot (40)](https://github.com/react-native-progress-view/progress-view/assets/30995198/84f64e07-f066-42e0-8601-066883bf17a4)
