### PR TITLE
Fix "fnv1a.h" not found when using the new architecture

### DIFF
--- a/react-native-progress-view.podspec
+++ b/react-native-progress-view.podspec
@@ -19,6 +19,8 @@ Pod::Spec.new do |s|
   s.ios.exclude_files= 'ios/Fabric'
   s.osx.source_files = 'macos/**/*.{h,m}'
 
+  install_modules_dependencies(s)
+
   if fabric_enabled
     folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
@@ -41,17 +43,10 @@ Pod::Spec.new do |s|
         'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17'
       }
 
-      s.dependency 'RCT-Folly'
-      s.dependency 'RCTRequired'
-      s.dependency 'RCTTypeSafety'
-      s.dependency 'ReactCommon/turbomodule/core'
-      ss.dependency 'React-Codegen'
-      ss.dependency 'React-RCTFabric'
-      ss.dependency 'React-Core'
-      ss.dependency 'React-utils'
       ss.dependency 'react-native-progress-view/common'
-      ss.source_files         = 'ios/Fabric/**/*.{h,m,mm}'
       ss.pod_target_xcconfig  = { 'HEADER_SEARCH_PATHS' => '\'$(PODS_TARGET_SRCROOT)/common/cpp\'' }
+      ss.source_files = 'ios/Fabric/**/*.{h,m,mm}'
+      install_modules_dependencies(ss)
     end
   else
     s.dependency 'React-Core'

--- a/react-native-progress-view.podspec
+++ b/react-native-progress-view.podspec
@@ -48,6 +48,7 @@ Pod::Spec.new do |s|
       ss.dependency 'React-Codegen'
       ss.dependency 'React-RCTFabric'
       ss.dependency 'React-Core'
+      ss.dependency 'React-utils'
       ss.dependency 'react-native-progress-view/common'
       ss.source_files         = 'ios/Fabric/**/*.{h,m,mm}'
       ss.pod_target_xcconfig  = { 'HEADER_SEARCH_PATHS' => '\'$(PODS_TARGET_SRCROOT)/common/cpp\'' }


### PR DESCRIPTION
When using the version from `master` in my project with the new architecture enabled on iOS, I'm getting the following error:

```
React-Fabric/React_Fabric.framework/Headers/react/renderer/core/PropsMacros.h:11:10)

   9 |
  10 | #include <react/renderer/core/RawPropsPrimitives.h>
> 11 | #include <react/utils/fnv1a.h>
     |          ^ 'react/utils/fnv1a.h' file not found
  12 | #include <functional>
```

By checking the template from the library recommended by the React Native team (https://reactnative.dev/docs/the-new-architecture/create-module-library), I noticed that the project was missing the `install_modules_dependencies` function.

With this change, projects running React Native 0.79 and Expo 53 build successfully again.